### PR TITLE
Use new interface for options layer

### DIFF
--- a/reactive/status.py
+++ b/reactive/status.py
@@ -1,9 +1,8 @@
 from charmhelpers.core.hookenv import atexit
 
 from charms import layer
-from charms.layer import status
 
 
-if layer.options('status')['patch-hookenv']:
-    status._patch_hookenv()
-atexit(status._finalize_status)
+if layer.options.get('status', 'patch-hookenv'):
+    layer.status._patch_hookenv()
+atexit(layer.status._finalize_status)


### PR DESCRIPTION
Layer options were pulled out into their own layer to work with multiple base layers and just generally be cleaner.  Part of that was to improve the interface to be a proper module and not just a function.