### PR TITLE
Fix status setting not working in actions

### DIFF
--- a/reactive/status.py
+++ b/reactive/status.py
@@ -1,8 +1,4 @@
-from charmhelpers.core.hookenv import atexit
-
 from charms import layer
 
 
-if layer.options.get('status', 'patch-hookenv'):
-    layer.status._patch_hookenv()
-atexit(layer.status._finalize_status)
+layer.status._initialize()


### PR DESCRIPTION
Because the finalizer may never be run when using an action, the status was never being sent to Juju.  This ensures that the status is properly finalized even when running an action, as well as properly handled when an action invokes the reactive bus as well.

Fixes #9