### PR TITLE
Use yaml.safe_load rather than yaml.load

### DIFF
--- a/lib/charms/layer/status.py
+++ b/lib/charms/layer/status.py
@@ -137,7 +137,7 @@ def _finalize():
         _statuses['_finalized'] = True
     charm_name = hookenv.charm_name()
     with Path('layer.yaml').open() as fp:
-        includes = yaml.load(fp.read()).get('includes', [])
+        includes = yaml.safe_load(fp.read()).get('includes', [])
     layer_order = includes + [charm_name]
 
     for workload_state in WorkloadState:


### PR DESCRIPTION
The default will change upstream but hasn't been released yet.
Being explicit suppresses a warning in the log.

Fixes #11