### PR TITLE
Fix errors being raised when a layer changes the current working directory

### DIFF
--- a/lib/charms/layer/status.py
+++ b/lib/charms/layer/status.py
@@ -136,7 +136,8 @@ def _finalize():
         # but subsequently starts the reactive bus.
         _statuses['_finalized'] = True
     charm_name = hookenv.charm_name()
-    with Path('layer.yaml').open() as fp:
+    charm_dir = Path(hookenv.charm_dir())
+    with charm_dir.joinpath('layer.yaml').open() as fp:
         includes = yaml.load(fp.read()).get('includes', [])
     layer_order = includes + [charm_name]
 


### PR DESCRIPTION
Because the finalizer uses a relative path to read `layer.yaml`, charms using `layer-status` raise errors if other layers change the current working directory to somewhere else.

This PR fixes this by using `hookenv.charm_dir()` to locate `layer.yaml`.
