### PR TITLE
Switching to safe yaml loading

### DIFF
--- a/lib/charms/layer/status.py
+++ b/lib/charms/layer/status.py
@@ -138,7 +138,7 @@ def _finalize():
     charm_name = hookenv.charm_name()
     charm_dir = Path(hookenv.charm_dir())
     with charm_dir.joinpath('layer.yaml').open() as fp:
-        includes = yaml.load(fp.read()).get('includes', [])
+        includes = yaml.safe_load(fp.read()).get('includes', [])
     layer_order = includes + [charm_name]
 
     for workload_state in WorkloadState:


### PR DESCRIPTION
Calling `yaml.load` without passing an explicit Loader class was deprecated due to safety concerns. The `yaml.safe_load` function is provided as a convenient alternative. This was creating some noise due to this warning:

    YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.